### PR TITLE
Fix service ip allocation

### DIFF
--- a/jagw/templates/proxy/proxy-deploy.yaml
+++ b/jagw/templates/proxy/proxy-deploy.yaml
@@ -29,9 +29,9 @@ spec:
           ports:
           - containerPort: {{ .Values.proxy.config.appServerPort }}
             protocol: TCP
-          - containerPort: {{ .Values.proxy.config.internalRequestServicePort }}
+          - containerPort: {{ .Values.proxy.config.internalRequestServicePort | default .Values.proxy.config.requestServicePort }}
             protocol: TCP
-          - containerPort: {{ .Values.proxy.config.internalSubscriptionServicePort }}
+          - containerPort: {{ .Values.proxy.config.internalSubscriptionServicePort | default .Values.proxy.config.subscriptionServicePort }}
             protocol: TCP
           {{- if .Values.imagePullSecrets }}
           imagePullPolicy: "{{ .Values.imagePullSecrets }}"

--- a/jagw/templates/proxy/proxy-svc.yaml
+++ b/jagw/templates/proxy/proxy-svc.yaml
@@ -13,14 +13,14 @@ spec:
     port: {{ .Values.proxy.config.subscriptionServicePort }}
     protocol: TCP
     targetPort: {{ .Values.proxy.config.subscriptionServicePort }}
-    {{- if and .Values.proxy.config.service.nodePort.subscriptionServiceNodePort (eq .Values.proxy.config.service.type "NodePort") }}
+    {{- if and (eq .Values.proxy.config.service.type "NodePort") .Values.proxy.config.service.nodePort.subscriptionServiceNodePort }}
     nodePort: {{ .Values.proxy.config.service.nodePort.subscriptionServiceNodePort }}
     {{- end }}
   - name: {{ .Values.requestService.name }}
     port: {{ .Values.proxy.config.requestServicePort }}
     protocol: TCP
     targetPort: {{ .Values.proxy.config.requestServicePort }}
-    {{- if and .Values.proxy.config.service.nodePort.requestServiceNodePort (eq .Values.proxy.config.service.type "NodePort") }}
+    {{- if and (eq .Values.proxy.config.service.type "NodePort") .Values.proxy.config.service.nodePort.requestServiceNodePort }}
     nodePort: {{ .Values.proxy.config.service.nodePort.requestServiceNodePort}}
     {{- end }}
   {{- if and .Values.proxy.config.loadBalancerIP (eq .Values.proxy.config.service.type "LoadBalancer") }}

--- a/jagw/templates/proxy/proxy-svc.yaml
+++ b/jagw/templates/proxy/proxy-svc.yaml
@@ -23,6 +23,6 @@ spec:
     {{- if and (eq .Values.proxy.config.service.type "NodePort") .Values.proxy.config.service.nodePort.requestServiceNodePort }}
     nodePort: {{ .Values.proxy.config.service.nodePort.requestServiceNodePort}}
     {{- end }}
-  {{- if and .Values.proxy.config.loadBalancerIP (eq .Values.proxy.config.service.type "LoadBalancer") }}
+  {{- if and (eq .Values.proxy.config.service.type "LoadBalancer") .Values.proxy.config.service.loadBalancerIP }}
   loadBalancerIP: "{{ .Values.proxy.config.service.loadBalancerIP }}"
   {{- end }}

--- a/jagw/values.yaml
+++ b/jagw/values.yaml
@@ -6,16 +6,16 @@ release:
   subscriptionServiceTag: v1.3.2
 
 config:
-  arangoDB: jalapeno-arangodb.sa-graph-properties-jalapeno.svc.cluster.local:8086
+  arangoDB: jalapeno-arangodb.jalapeno.svc.cluster.local:8086
   arangoDBUser: root
   arangoDBPassword: jalapeno
   arangoDBName: jalapeno
   redisPassword: a-very-complex-password-here
   sentinelPassword: a-very-complex-password-here
-  sentinelAddress: jagw-redis.sa-graph-properties-jagw.svc.cluster.local:26379
+  sentinelAddress: jagw-redis.jagw-dev.svc.cluster.local:26379
   sentinelMaster: mymaster
-  kafkaAddress: kafka.sa-graph-properties-jalapeno.svc.cluster.local:9092
-  influxDBUrl: influxdb.sa-graph-properties-jalapeno.svc.cluster.local:8086
+  kafkaAddress: kafka.jalapeno.svc.cluster.local:9092
+  influxDBUrl: influxdb.jalapeno.svc.cluster.local:8086
   influxDBUser: admin #root # needs to match influxUser in Jalapeno Deployment
   influxDBPassword: gsplabgsplab # jalapeno # needs to match influxPassword in Jalapeno deployment
   influxDB: mdt_db
@@ -45,14 +45,13 @@ requestService:
   name: request-service
   replicas: 1
   image:
-    repository: ghcr.io/jalapeno-api-gateway/request-service 
+    repository: ghcr.io/jalapeno-api-gateway/request-service
     pullPolicy: Always
   resources: []
   config:
     appServerAddress: 0.0.0.0
     appServerPort: 9000
   logLevel: trace
-
 
 # Official bitnami/stable charts
 # The charts are defined in the Charts.yaml as dependency
@@ -61,7 +60,7 @@ redis:
   global:
     redis:
       password: a-very-complex-password-here
-  
+
   image:
     registry: docker.io
     repository: bitnami/redis
@@ -81,13 +80,11 @@ proxy:
   config:
     appServerAddress: 0.0.0.0
     appServerPort: 9901
-    internalSubscriptionServicePort: 9902
     subscriptionServicePort: 9902
-    internalRequestServicePort: 9903
     requestServicePort: 9903
     service:
       type: LoadBalancer
       loadBalancerIP: "152.96.8.37"
-      # nodePort: Optional (only if no loadBalancer is used)
-        # subscriptionServiceNodePort: 31146
-        # requestServiceNodePort: 31147
+      # nodePort: Optional (only if NodePort is used)
+      # subscriptionServiceNodePort: 31146
+      # requestServiceNodePort: 31147

--- a/jagw/values.yaml
+++ b/jagw/values.yaml
@@ -84,7 +84,7 @@ proxy:
     requestServicePort: 9903
     service:
       type: LoadBalancer
-      loadBalancerIP: "152.96.8.37"
+      loadBalancerIP: "152.96.8.37" # Omit for automatic IP assignment
       # nodePort: Optional (only if NodePort is used)
       # subscriptionServiceNodePort: 31146
       # requestServiceNodePort: 31147

--- a/jagw/values.yaml
+++ b/jagw/values.yaml
@@ -1,21 +1,21 @@
 imagePullSecrets: []
 
 release:
-  cacheServiceTag: dev-43
-  requestServiceTag: dev-43
-  subscriptionServiceTag: dev-43
+  cacheServiceTag: v1.3.2
+  requestServiceTag: v1.3.2
+  subscriptionServiceTag: v1.3.2
 
 config:
-  arangoDB: jalapeno-arangodb.jalapeno.svc.cluster.local:8086
+  arangoDB: jalapeno-arangodb.sa-graph-properties-jalapeno.svc.cluster.local:8086
   arangoDBUser: root
   arangoDBPassword: jalapeno
   arangoDBName: jalapeno
   redisPassword: a-very-complex-password-here
   sentinelPassword: a-very-complex-password-here
-  sentinelAddress: jagw-redis.jagw-dev-dominique.svc.cluster.local:26379
+  sentinelAddress: jagw-redis.sa-graph-properties-jagw.svc.cluster.local:26379
   sentinelMaster: mymaster
-  kafkaAddress: kafka.jalapeno.svc.cluster.local:9092
-  influxDBUrl: influxdb.jalapeno.svc.cluster.local:8086
+  kafkaAddress: kafka.sa-graph-properties-jalapeno.svc.cluster.local:9092
+  influxDBUrl: influxdb.sa-graph-properties-jalapeno.svc.cluster.local:8086
   influxDBUser: admin #root # needs to match influxUser in Jalapeno Deployment
   influxDBPassword: gsplabgsplab # jalapeno # needs to match influxPassword in Jalapeno deployment
   influxDB: mdt_db
@@ -24,10 +24,9 @@ subscriptionService:
   name: subscription-service
   replicas: 1
   image:
-    repository: insost/jagw-subscription-service
+    repository: ghcr.io/jalapeno-api-gateway/subscription-service
     pullPolicy: Always
   resources: []
-  # nodePort: 30060
   config:
     appServerAddress: 0.0.0.0
     appServerPort: 9000
@@ -37,7 +36,7 @@ cacheService:
   name: cache-service
   replicas: 1
   image:
-    repository: insost/jagw-cache-service
+    repository: ghcr.io/jalapeno-api-gateway/cache-service
     pullPolicy: Always
   resources: []
   logLevel: trace
@@ -46,14 +45,30 @@ requestService:
   name: request-service
   replicas: 1
   image:
-    repository: insost/jagw-request-service
+    repository: ghcr.io/jalapeno-api-gateway/request-service 
     pullPolicy: Always
   resources: []
-  # nodePort: 30061
   config:
     appServerAddress: 0.0.0.0
     appServerPort: 9000
   logLevel: trace
+
+
+# Official bitnami/stable charts
+# The charts are defined in the Charts.yaml as dependency
+# https://artifacthub.io/packages/helm/bitnami/redis
+redis:
+  global:
+    redis:
+      password: a-very-complex-password-here
+  
+  image:
+    registry: docker.io
+    repository: bitnami/redis
+    tag: 7.0.4-debian-11-r17
+
+  sentinel:
+    enabled: true
 
 proxy:
   name: envoy-proxy
@@ -66,25 +81,13 @@ proxy:
   config:
     appServerAddress: 0.0.0.0
     appServerPort: 9901
+    internalSubscriptionServicePort: 9902
     subscriptionServicePort: 9902
+    internalRequestServicePort: 9903
     requestServicePort: 9903
     service:
       type: LoadBalancer
-      loadBalancerIP: "172.16.19.71"
-      nodePort:
-        subscriptionServiceNodePort: 31146
-        requestServiceNodePort: 31147
-
-# Official bitnami/stable charts
-# The charts are defined in the Charts.yaml as dependency
-# https://artifacthub.io/packages/helm/bitnami/redis
-redis:
-  global:
-    redis:
-      password: a-very-complex-password-here
-  image:
-    registry: docker.io
-    repository: bitnami/redis
-    tag: 7.0.4-debian-11-r17
-  sentinel:
-    enabled: true
+      loadBalancerIP: "152.96.8.37"
+      # nodePort: Optional (only if no loadBalancer is used)
+        # subscriptionServiceNodePort: 31146
+        # requestServiceNodePort: 31147


### PR DESCRIPTION
These changes ensure that the defined load balancer IP is used. Before the first available IP address of the load balancer subnet was used. Please take a look at the differences and merge them if they look good to you.