### PR TITLE
update cache- request and subscription service from v1.3.2 to v1.3.3

### DIFF
--- a/jagw/values.yaml
+++ b/jagw/values.yaml
@@ -1,9 +1,9 @@
 imagePullSecrets: []
 
 release:
-  cacheServiceTag: v1.3.2
-  requestServiceTag: v1.3.2
-  subscriptionServiceTag: v1.3.2
+  cacheServiceTag: v1.3.3
+  requestServiceTag: v1.3.3
+  subscriptionServiceTag: v1.3.3
 
 config:
   arangoDB: jalapeno-arangodb.jalapeno.svc.cluster.local:8086


### PR DESCRIPTION
Adjust the helm to support the latest version of the jalapeno API GW services (cache-, subscription, request-service).