### PR TITLE
Change release version to v1.4.0

### DIFF
--- a/jagw/values.yaml
+++ b/jagw/values.yaml
@@ -1,9 +1,9 @@
 imagePullSecrets: []
 
 release:
-  cacheServiceTag: v1.3.3
-  requestServiceTag: v1.3.3
-  subscriptionServiceTag: v1.3.3
+  cacheServiceTag: v1.4.0
+  requestServiceTag: v1.4.0
+  subscriptionServiceTag: v1.4.0
 
 config:
   arangoDB: jalapeno-arangodb.jalapeno.svc.cluster.local:8086


### PR DESCRIPTION
Changed the release versions of the cache-, request and subscription services to [v1.4.0](https://github.com/jalapeno-api-gateway/jagw/releases/tag/v1.4.0)