### PR TITLE
Fix redis-sentinel repository for Bitnami chart dependency

### DIFF
--- a/jagw/values.yaml
+++ b/jagw/values.yaml
@@ -7,13 +7,13 @@ release:
 
 # Change to your own needs
 config:
-  arangoDB: jalapeno-arangodb.jalapeno.svc.cluster.local:8086 
+  arangoDB: arangodb.jalapeno.svc.cluster.local:8529
   arangoDBUser: root
   arangoDBPassword: jalapeno
   arangoDBName: jalapeno
   redisPassword: a-very-complex-password-here
   sentinelPassword: a-very-complex-password-here
-  sentinelAddress: jagw-redis.jagw-dev.svc.cluster.local:26379  
+  sentinelAddress: jagw-redis.jagw.svc.cluster.local:26379
   sentinelMaster: mymaster
   kafkaAddress: kafka.jalapeno.svc.cluster.local:9092
   influxDBUrl: influxdb.jalapeno.svc.cluster.local:8086

--- a/jagw/values.yaml
+++ b/jagw/values.yaml
@@ -69,6 +69,10 @@ redis:
 
   sentinel:
     enabled: true
+    image:
+      registry: docker.io
+      repository: bitnamilegacy/redis-sentinel
+      tag: 7.0.4-debian-11-r17
 
 proxy:
   name: envoy-proxy


### PR DESCRIPTION
We missed something in #63 , sentinel also needs an image that is now only available in `bitnamilegacy`.

This also modifies the default values to be more in line with the current state of the [jalapeno-helm](https://github.com/jalapeno-api-gateway/jalapeno-helm) chart:

- The service names no longer have the `jalapeno-` prefix (except for Grafana)
- The port number for ArangoDB has changed
- The docs also use `jagw` as the namespace, not `jagw-dev`: https://jalapeno-api-gateway.github.io/jagw/docs/installation#3-create-a-namespace-1